### PR TITLE
Replace previous installation removal code

### DIFF
--- a/src/RemovePriorInstallation.nsh
+++ b/src/RemovePriorInstallation.nsh
@@ -1,62 +1,68 @@
 !macro RemovePreviousInstall
-    SetRegView 32
-    ClearErrors
-    EnumRegKey $0 HKLM32 "SOFTWARE\EA GAMES\The Sims 2" 0
+SetRegView 32
+ClearErrors
+${GetGameRegKey} $R4
 IfErrors keydontexist keyexists
 goto noo
 keyexists:
-        ReadRegStr $R4 HKLM32 "SOFTWARE\EA GAMES\The Sims 2" "Folder" 
-        MessageBox MB_YESNO|MB_ICONEXCLAMATION "A previous installation of The Sims 2 was detected on this system. Leaving behind remnants in the registry can cause unwanted behavior. Would you like the installer to remove the conflicting installation?$\n$\nWARNING: this will remove the registry keys we detected, rendering the old installation unplayable. Your game/save file directories will not be affected." IDYES si IDNO noo
+MessageBox MB_YESNO|MB_ICONEXCLAMATION "A previous installation of The Sims 2 was detected on this system. Leaving behind remnants in the registry can cause unwanted behavior. Would you like the installer to remove the conflicting installation?$\n$\nWARNING: this will remove the registry keys we detected, rendering the old installation unplayable. Your game/save file directories will not be affected." IDYES si IDNO noo
 si:
-            ReadRegStr $R4 HKLM32 "SOFTWARE\EA GAMES\The Sims 2" "Folder" 
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Apartment Life"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Bon Voyage"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Celebration Stuff"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Family Fun Stuff"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 FreeTime"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Glamour Life Stuff"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 H M Fashion Stuff"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 IKEA Home Stuff"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Kitchen & Bath Interior Design Stuff"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Mansion and Garden Stuff"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Nightlife"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Open For Business"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Pets"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Seasons"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Teen Style Stuff"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 University"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Best of Business Collection"    
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 University Life Collection"
-            DeleteRegKey HKLM32 "SOFTWARE\EA GAMES\The Sims 2 Fun with Pets Collection"
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\The Sims 2 Starter Pack"
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2EP1.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2EP2.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2EP3.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2EP4.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2EP5.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2EP6.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2EP7.exe"
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2EP8.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2EP9.exe"
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2SC.exe"
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2SP1.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2SP2.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2SP4.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2SP5.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2SP6.exe"	
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2SP7.exe"
-            DeleteRegKey HKLM32 "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Sims2SP8.exe"	
-            MessageBox MB_YESNO|MB_ICONEXCLAMATION "Would you like to remove the game files the old registry keys pointed to at: '$R4'? (Save files will not be removed, only game files.)" IDYES yassdelete IDNO nodelete
-            yassdelete:
-                RMDir /r $R4
-                Pop $0
-                DetailPrint "$R4 has been deleted. Delete result: $0"
-            nodelete:    
-                goto noo
-keydontexist:
-        #key doesn't exist
-        DetailPrint "No prior installations were detected. Yay!"
-noo:
-!macroend
+${DeleteGameRegKey}
+MessageBox MB_YESNO|MB_ICONEXCLAMATION "Would you like to remove the game files the old registry keys pointed to at: '$R4'? (Save files will not be removed, only game files.)" IDYES yassdelete IDNO done
+yassdelete:
+Delete "$R4*.*"
+RMDir "$R4"
+done:
+goto done
+
+Function GetGameRegKey
+Exch $0 ; return value
+Push "SOFTWARE\EA GAMES\The Sims 2"
+Call ReadRegStr $0 HKLM32
+Pop $1
+StrCmp $0 "" 0 +2 ; if $0 is empty, skip two lines
+StrCpy $0 $1
+FunctionEnd
+
+Function DeleteGameRegKey
+Push "SOFTWARE\EA GAMES\The Sims 2"
+${GetGameRegKey} $0
+DeleteRegKey HKLM32 $0
+${DeleteExpansionRegKey} "Apartment Life"
+${DeleteExpansionRegKey} "Bon Voyage"
+${DeleteExpansionRegKey} "Celebration Stuff"
+${DeleteExpansionRegKey} "Family Fun Stuff"
+${DeleteExpansionRegKey} "FreeTime"
+${DeleteExpansionRegKey} "Glamour Life Stuff"
+${DeleteExpansionRegKey} "H M Fashion Stuff"
+${DeleteExpansionRegKey} "IKEA Home Stuff"
+${DeleteExpansionRegKey} "Kitchen & Bath Interior Design Stuff"
+${DeleteExpansionRegKey} "Mansion and Garden Stuff"
+${DeleteExpansionRegKey} "Nightlife"
+${DeleteExpansionRegKey} "Open For Business"
+${DeleteExpansionRegKey} "Pets"
+${DeleteExpansionRegKey} "Seasons"
+${DeleteExpansionRegKey} "Teen Style Stuff"
+${DeleteExpansionRegKey} "University"
+${DeleteExpansionRegKey} "Best of Business Collection"
+${DeleteExpansionRegKey} "University Life Collection"
+${DeleteExpansionRegKey} "Fun with Pets Collection"
+${DeleteUninstallRegKey} "The Sims 2 Starter Pack"
+${DeleteAppPathRegKey} "Sims2.exe"
+${DeleteAppPathRegKey} "Sims2EP1.exe"
+${DeleteAppPathRegKey} "Sims2EP2.exe
+${DeleteAppPathRegKey} "Sims2EP3.exe"
+${DeleteAppPathRegKey} "Sims2EP4.exe"
+${DeleteAppPathRegKey} "Sims2EP5.exe"
+${DeleteAppPathRegKey} "Sims2EP6.exe"
+${DeleteAppPathRegKey} "Sims2EP7.exe"
+${DeleteAppPathRegKey} "Sims2EP8.exe"
+${DeleteAppPathRegKey} "Sims2EP9.exe"
+${DeleteAppPathRegKey} "Sims2SC.exe"
+${DeleteAppPathRegKey} "Sims2SP1.exe"
+${DeleteAppPathRegKey} "Sims2SP2.exe"
+${DeleteAppPathRegKey} "Sims2SP4.exe"
+${DeleteAppPathRegKey} "Sims2SP5.exe"
+${DeleteAppPathRegKey} "Sims2SP6.exe"
+${DeleteAppPathRegKey} "Sims2SP7.exe"
+${DeleteAppPathRegKey} "Sims2SP8.exe"


### PR DESCRIPTION
This PR replaces the manual deletion of conflicting game installations with a function in the installer script. The previous implementation had the potential to cause unwanted behavior by leaving behind remnants in the registry. The new function removes conflicting registry keys and game files cleanly, ensuring that the old installation is rendered unplayable without affecting the save file directories. This improves the reliability and safety of the installer, reducing the risk of conflicts or issues during installation.